### PR TITLE
Change init to new

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -24,9 +24,9 @@ local lighting --- @type LightingConfig
 function _init()
 	poke4(0x5000, fetch(DATP.."pal/0.pal"):get())
 
-	screen_manager = m_screen_manager.init(include"src/screen_data.lua","start")
+	screen_manager = m_screen_manager.new(include"src/screen_data.lua","start")
 
-	player = m_player.init(
+	player = m_player.new(
 		screen_manager.screen.path,m_pathfinding.new_path_position(0.5,1)
 	)
 	entities = {
@@ -38,7 +38,7 @@ function _init()
 	local identity_coltab = userdata("u8",64,64)
 	identity_coltab:peek(0x9000,0,64*64)
 
-	lighting = m_lighting.init(
+	lighting = m_lighting.new(
 		default_coltab,
 		identity_coltab,
 		get_spr(ILLUMINATION_CT_INDEX)

--- a/src/lighting.lua
+++ b/src/lighting.lua
@@ -24,12 +24,12 @@ local function draw_lit(self,draw_call,illuminance_map,pos,size)
 	poke(0x550A,0x3F)
 end
 
---- Initializes the lighting configuration.
+--- Creates a lighting configuration.
 --- @param default_coltab userdata The default color table.
 --- @param identity_coltab userdata The identity color table. (All transparent)
 --- @param illuminance_coltab userdata The illuminance color table.
 --- @return LightingConfig lighting The new lighting configuration.
-local function init(default_coltab,identity_coltab,illuminance_coltab)
+local function new(default_coltab,identity_coltab,illuminance_coltab)
 	--- @class LightingConfig Holds on to relevant color tables for lighting effects.
 	--- @field default_coltab userdata The default color table.
 	--- @field identity_coltab userdata The identity color table. (All transparent)
@@ -44,5 +44,5 @@ local function init(default_coltab,identity_coltab,illuminance_coltab)
 end
 
 return {
-	init = init,
+	new = new,
 }

--- a/src/player.lua
+++ b/src/player.lua
@@ -10,11 +10,11 @@ local function animation_listener(_,frame_events)
 	end
 end
 
---- Creates the player
+--- Creates a player entity.
 --- @param path Path The path that the player is spawned on.
 --- @param path_pos PathPosition The position on the path that the player is spawned at.
 --- @return Player player The new player object.
-local function init(path,path_pos)
+local function new(path,path_pos)
 	--- @class Player The player character.
 	--- @field entity Entity The entity of the player.
 	player = {
@@ -25,5 +25,5 @@ local function init(path,path_pos)
 end
 
 return {
-	init = init,
+	new = new,
 }

--- a/src/screen_manager.lua
+++ b/src/screen_manager.lua
@@ -5,14 +5,14 @@ local m_screens = require"src/screens"
 --- @param screen Screen The screen to set as the current screen.
 local function set_screen(self,screen)
 	self.screen = screen
-	self.screen:init()
+	self.screen:enter()
 end
 
---- Initializes a new screen manager.
+--- Creates a new screen manager.
 --- @param screen_data table<string,ScreenData> The data for the screens available to the manager.
 --- @param initial_screen_key string The key of the initial screen to set.
 --- @return ScreenManager screen_manager The new screen manager.
-local function init(screen_data,initial_screen_key)
+local function new(screen_data,initial_screen_key)
 	local screens = m_screens.import(screen_data)
 	local initial_screen = screens[initial_screen_key]
 	assert(initial_screen,"Cannot initialize screen manager with invalid screen key: "..initial_screen_key)
@@ -32,5 +32,5 @@ local function init(screen_data,initial_screen_key)
 end
 
 return {
-	init = init,
+	new = new,
 }

--- a/src/screens.lua
+++ b/src/screens.lua
@@ -9,7 +9,7 @@ local m_pathfinding = require"src/pathfinding"
 
 --- Initializes the screen.
 --- @param self Screen
-local function init(self)
+local function enter(self)
 	music(self.data.music or -1)
 end
 
@@ -23,7 +23,7 @@ local function new_screen(data)
 	local screen = {
 		data = data,
 		path = m_pathfinding.new_path(data.path.nodes, data.path.edges),
-		init = init,
+		enter = enter,
 	}
 	return screen
 end


### PR DESCRIPTION
Renames all `init` functions to `new`. Not really a good reason to make a distinction between instanceable managers and instanceable objects.